### PR TITLE
Section contents mixin handles no subsections

### DIFF
--- a/mixins/section-contents.pug
+++ b/mixins/section-contents.pug
@@ -17,12 +17,14 @@ mixin sectionContents
 
     - var docsRoot = environment === 'production' ? PROD_ROOT : DEV_ROOT
 
-    ul.c-section-contents.u-list-style-none
-        each childNode, slug in node._data
-            if (!(slug.startsWith('_') || slug === "styleguidist" || slug === "index"))
-                - url = docsRoot + localPath.join('/') + '/' + slug
-                li
-                    a.c-card(href=url)
-                        h2.c-card__heading.c-heading.c--h3 #{childNode.title}
-                        if childNode.intro
-                            p.c-card__message #{childNode.intro}
+    // Render nothing and don't crash if we call this mixin on a section without children
+    if (node._data)
+        ul.c-section-contents.u-list-style-none
+            each childNode, slug in node._data
+                if (!(slug.startsWith('_') || slug === "styleguidist" || slug === "index"))
+                    - url = docsRoot + localPath.join('/') + '/' + slug
+                    li
+                        a.c-card(href=url)
+                            h2.c-card__heading.c-heading.c--h3 #{childNode.title}
+                            if childNode.intro
+                                p.c-card__message #{childNode.intro}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mobify/documentation-theme",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1219,23 +1219,6 @@
         "terraform": "github:mobify/terraform#795c6b2914991187308e8e52d6ac9a3ca3f06c40"
       },
       "dependencies": {
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          }
-        },
         "commander": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.0.0.tgz",
@@ -1250,11 +1233,6 @@
             "jsonfile": "2.4.0",
             "rimraf": "2.6.2"
           }
-        },
-        "get-stdin": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-          "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4="
         },
         "graceful-fs": {
           "version": "3.0.11",
@@ -1278,63 +1256,6 @@
               "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
               "optional": true
             }
-          }
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-          "requires": {
-            "minimist": "0.0.8"
-          }
-        },
-        "node-sass": {
-          "version": "4.5.3",
-          "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.5.3.tgz",
-          "integrity": "sha1-0JydEXlkEjnRuX/8YjH9zsU+FWg=",
-          "requires": {
-            "async-foreach": "0.1.3",
-            "chalk": "1.1.3",
-            "cross-spawn": "3.0.1",
-            "gaze": "1.1.2",
-            "get-stdin": "4.0.1",
-            "glob": "7.1.2",
-            "in-publish": "2.0.0",
-            "lodash.assign": "4.2.0",
-            "lodash.clonedeep": "4.5.0",
-            "lodash.mergewith": "4.6.0",
-            "meow": "3.7.0",
-            "mkdirp": "0.5.1",
-            "nan": "2.8.0",
-            "node-gyp": "3.6.2",
-            "npmlog": "4.1.2",
-            "request": "2.83.0",
-            "sass-graph": "2.2.4",
-            "stdout-stream": "1.4.0"
-          }
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-        },
-        "terraform": {
-          "version": "github:mobify/terraform#795c6b2914991187308e8e52d6ac9a3ca3f06c40",
-          "requires": {
-            "autoprefixer": "7.1.2",
-            "coffee-script": "1.12.7",
-            "ejs": "2.5.7",
-            "harp-minify": "0.4.0",
-            "less": "2.7.2",
-            "lodash": "4.17.4",
-            "lru-cache": "4.1.1",
-            "marked": "0.3.6",
-            "node-sass": "4.5.3",
-            "postcss": "6.0.8",
-            "pug": "2.0.0-rc.4",
-            "resolve": "1.5.0",
-            "stylus": "0.54.5",
-            "through": "2.3.8"
           }
         }
       }
@@ -3336,6 +3257,87 @@
       "integrity": "sha1-fWtxAEcznTn4RzJ6BW2t8YMQMBA=",
       "requires": {
         "uuid": "1.4.2"
+      }
+    },
+    "terraform": {
+      "version": "github:mobify/terraform#795c6b2914991187308e8e52d6ac9a3ca3f06c40",
+      "requires": {
+        "autoprefixer": "7.1.2",
+        "coffee-script": "1.12.7",
+        "ejs": "2.5.7",
+        "harp-minify": "0.4.0",
+        "less": "2.7.2",
+        "lodash": "4.17.4",
+        "lru-cache": "4.1.1",
+        "marked": "0.3.6",
+        "node-sass": "4.5.3",
+        "postcss": "6.0.8",
+        "pug": "2.0.0-rc.4",
+        "resolve": "1.5.0",
+        "stylus": "0.54.5",
+        "through": "2.3.8"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
+        },
+        "get-stdin": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+          "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4="
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "node-sass": {
+          "version": "4.5.3",
+          "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.5.3.tgz",
+          "integrity": "sha1-0JydEXlkEjnRuX/8YjH9zsU+FWg=",
+          "requires": {
+            "async-foreach": "0.1.3",
+            "chalk": "1.1.3",
+            "cross-spawn": "3.0.1",
+            "gaze": "1.1.2",
+            "get-stdin": "4.0.1",
+            "glob": "7.1.2",
+            "in-publish": "2.0.0",
+            "lodash.assign": "4.2.0",
+            "lodash.clonedeep": "4.5.0",
+            "lodash.mergewith": "4.6.0",
+            "meow": "3.7.0",
+            "mkdirp": "0.5.1",
+            "nan": "2.8.0",
+            "node-gyp": "3.6.2",
+            "npmlog": "4.1.2",
+            "request": "2.83.0",
+            "sass-graph": "2.2.4",
+            "stdout-stream": "1.4.0"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+        }
       }
     },
     "through": {


### PR DESCRIPTION
Make the mixin smarter so that if we happen to call this partial on a page with no subsections it doesn't blow up (i.e. renders nothing!). This makes it easier to handle special cases we may encounter without complex logic to detect this is happening. See https://github.com/mobify/documentation-hub/pull/149 for why this is needed and how to test this PR.