### PR TITLE
Dont render accordion links if _excludeFromMenu is set to true

### DIFF
--- a/mixins/sidebar.pug
+++ b/mixins/sidebar.pug
@@ -32,7 +32,8 @@ mixin buildMenu
                     .sdk-sidebar__accordion-title= category.title
                 ul.sdk-sidebar__accordion-item.u-list-style-none(style={ 'max-height': isActiveCategory ? 'initial': '' })
                     for document, documentSlug in documents
-                        a.sdk-sidebar__list-link(href=`${DOCS_ROOT}${version}/${categorySlug}/${documentSlug}` class={ 'c--active': documentSlug === path[2] })= document.title
+                        unless document._excludeFromMenu
+                            a.sdk-sidebar__list-link(href=`${DOCS_ROOT}${version}/${categorySlug}/${documentSlug}` class={ 'c--active': documentSlug === path[2] })= document.title
 
 mixin sidebar
     - var isDocumentationHub = PROJECT_NAME === 'Documentation Home'


### PR DESCRIPTION
This PR allows sub-menu items to be hidden from the rendered menu. 

 **JIRA**: https://mobify.atlassian.net/browse/DESKTOP-185

## Changes
- Check if accordion link has _excludeFromMenu set to true before rendering

## How to test-drive this PR
- checkout this branch 
- run `npm i`
- run `npm link`
- checkout the `DESKTOP-185__upwa-debugging-guide` branch of the SDK
- run `npm link @mobify/documentation-theme`
- run `npm run docs:dev`
- view the docs at http://localhost:9000/latest/
- open the guides section in the sidebar
- the "Debugging Universal PWAs" guide should not be visible in the Guides section