### PR TITLE
Windows paths

### DIFF
--- a/layouts/404.pug
+++ b/layouts/404.pug
@@ -1,4 +1,4 @@
-extends ./base
+extends base
 
 //- 🚫 404 Page.
 include ../mixins/header-top

--- a/layouts/404.pug
+++ b/layouts/404.pug
@@ -1,4 +1,4 @@
-extends ../mixins/base
+extends ../layouts/base
 
 //- 🚫 404 Page.
 include ../mixins/header-top

--- a/layouts/404.pug
+++ b/layouts/404.pug
@@ -1,4 +1,4 @@
-extends base
+extends ../mixins/base
 
 //- 🚫 404 Page.
 include ../mixins/header-top

--- a/layouts/search.pug
+++ b/layouts/search.pug
@@ -1,5 +1,5 @@
 //- 🔍Search Page.
-extends ./base
+extends ../mixins/base
 include ../mixins/header-top
 include ../mixins/search-box
 

--- a/layouts/search.pug
+++ b/layouts/search.pug
@@ -1,5 +1,5 @@
 //- 🔍Search Page.
-extends ../mixins/base
+extends ../layouts/base
 include ../mixins/header-top
 include ../mixins/search-box
 

--- a/layouts/search.pug
+++ b/layouts/search.pug
@@ -1,5 +1,5 @@
 //- 🔍Search Page.
-extends ./base
+extends base
 include ../mixins/header-top
 include ../mixins/search-box
 

--- a/layouts/search.pug
+++ b/layouts/search.pug
@@ -1,5 +1,5 @@
 //- 🔍Search Page.
-extends base
+extends ./base
 include ../mixins/header-top
 include ../mixins/search-box
 

--- a/mixins/header-top.pug
+++ b/mixins/header-top.pug
@@ -1,4 +1,4 @@
-include ./logo
+include ../mixins/logo
 
 mixin headerTop
     div.u-padding-top-sm.u-padding-bottom-sm.u-clearfix.u-flexbox.u-align-center

--- a/mixins/header.pug
+++ b/mixins/header.pug
@@ -1,5 +1,5 @@
-include ./top-nav
-include ./version-picker
+include ../mixins/top-nav
+include ../mixins/version-picker
 
 mixin header(title, intro, hasPicker)
     - title = title || SITE_TITLE

--- a/mixins/sidebar.pug
+++ b/mixins/sidebar.pug
@@ -1,4 +1,4 @@
-include ./logo
+include ../mixins/logo
 
 - var path = [].concat(current.path)
 //- This is a "version" for some projects, and a "product" for others

--- a/mixins/top-nav.pug
+++ b/mixins/top-nav.pug
@@ -1,4 +1,4 @@
-include ./logo
+include ../mixins/logo
 
 mixin top-nav
     div.c-contain.u-flexbox.u-justify-between.u-margin-bottom-lg.u-align-center.u-hidden--for-tablet-landscape-up

--- a/scripts/create-version-link.js
+++ b/scripts/create-version-link.js
@@ -16,7 +16,7 @@ const symlink = (newVersion, docsDir) => {
 
     console.log(`Creating symlink to ${docsDir.version} at ${linkPath}`)
     return fs
-        .symlink(docsDir.version, linkPath, 'dir')
+        .symlink(docsDir.version, linkPath, 'junction')
         .then(() => {
             console.log(`Symlink successful`)
             return path.resolve(linkPath)

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -24,7 +24,7 @@ const remove = (location) => {
  * @param {string} dirString
  */
 const docsDirInfo = (dirString) => {
-    const split = dirString.split('/')
+    const split = dirString.split(path.sep)
     const publicFolderIndex = split.indexOf(HARP_PUBLIC_FOLDER)
     // Harp uses a conventional 'public' folder to store documentation in
     const root = split[publicFolderIndex - 1] || ''

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -24,7 +24,7 @@ const remove = (location) => {
  * @param {string} dirString
  */
 const docsDirInfo = (dirString) => {
-    const split = dirString.split(path.sep)
+    const split = dirString.split('/')
     const publicFolderIndex = split.indexOf(HARP_PUBLIC_FOLDER)
     // Harp uses a conventional 'public' folder to store documentation in
     const root = split[publicFolderIndex - 1] || ''


### PR DESCRIPTION
We need that everything should be cross-platform compatible i.e. compatible with both Windows and Unix systems. So, to achieve that, main changes include:
- Use `path.sep` instead of '/' (Unix based) and '\' (Windows based)
- use option 'junction' instead of 'dir' when symlink command is run so that it could convert to absolute path automatically (this is required in case of Windows)